### PR TITLE
Add support for generated fields

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: cycle

--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -24,10 +24,13 @@ jobs:
             extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
           - php: '8.1'
-            extensions: pdo, pdo_sqlsrv-5.11.0
+            extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
           - php: '8.2'
-            extensions: pdo, pdo_sqlsrv-5.11.0
+            extensions: pdo, pdo_sqlsrv
+            mssql: 'server:2019-latest'
+          - php: '8.3'
+            extensions: pdo, pdo_sqlsrv
             mssql: 'server:2019-latest'
 
     services:
@@ -68,11 +71,11 @@ jobs:
         run: composer self-update
 
       - name: Install dependencies with composer
-        if: matrix.php != '8.2'
+        if: matrix.php != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Run tests with phpunit without coverage

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -23,6 +23,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
         mysql-version:
           - "5.7"
@@ -79,11 +80,11 @@ jobs:
             php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
 
       - name: Install dependencies with composer
-        if: matrix.php-version != '8.2'
+        if: matrix.php-version != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php-version == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php-version == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Run mysql tests with phpunit

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -22,6 +22,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
 
         pgsql-version:
           - "10"
@@ -80,11 +81,11 @@ jobs:
             php${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
 
       - name: Install dependencies with composer
-        if: matrix.php-version != '8.2'
+        if: matrix.php-version != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php-version == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php-version == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Run pgsql tests with phpunit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,8 @@ jobs:
         php-version:
           - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -42,10 +43,10 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
       - name: Install dependencies with composer
-        if: matrix.php-version != '8.2'
+        if: matrix.php-version != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php-version == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php-version == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
       - name: Execute Tests
         run: |
@@ -95,11 +96,11 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies with composer
-        if: matrix.php-version != '8.2'
+        if: matrix.php-version != '8.4'
         run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
-      - name: Install dependencies with composer php 8.2
-        if: matrix.php-version == '8.2'
+      - name: Install dependencies with composer php 8.4
+        if: matrix.php-version == '8.4'
         run: composer update --ignore-platform-reqs --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 
       - name: Execute Tests

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,47 +1,14 @@
+on:
+    pull_request: null
+    push:
+        branches:
+            - '*.*'
+
 name: static analysis
 
-on: [push, pull_request]
-
 jobs:
-    mutation:
-        name: PHP ${{ matrix.php }}-${{ matrix.os }}
-
-        runs-on: ${{ matrix.os }}
-
-        strategy:
-            matrix:
-                os:
-                    - ubuntu-latest
-
-                php:
-                    - "8.2"
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2.3.4
-
-            - name: Install PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: "${{ matrix.php }}"
-                  tools: composer:v2, cs2pr
-                  coverage: none
-
-            - name: Determine composer cache directory
-              run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
-
-            - name: Cache dependencies installed with composer
-              uses: actions/cache@v2
-              with:
-                  path: ${{ env.COMPOSER_CACHE_DIR }}
-                  key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: |
-                      php${{ matrix.php }}-composer-
-            - name: Update composer
-              run: composer self-update
-
-            - name: Install dependencies with composer
-              run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
-
-            - name: Static analysis
-              run: vendor/bin/psalm --shepherd --stats --output-format=checkstyle
+    psalm:
+        uses: spiral/gh-actions/.github/workflows/psalm.yml@master
+        with:
+            os: >-
+                ['ubuntu-latest']

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "require": {
         "php": ">=8.0",
-        "cycle/entity-behavior": "^1.0",
+        "cycle/entity-behavior": "^1.3",
         "ramsey/uuid": "^4.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,39 @@
 {
     "name": "cycle/entity-behavior-uuid",
     "type": "library",
+    "license": "MIT",
+    "description": "Provides an ability to use ramsey/uuid as a Cycle ORM entity column type",
+    "homepage": "https://cycle-orm.dev",
+    "support": {
+        "issues": "https://github.com/cycle/entity-behavior-uuid/issues",
+        "source": "https://github.com/cycle/entity-behavior-uuid",
+        "docs": "https://cycle-orm.dev/docs",
+        "chat": "https://discord.gg/spiralphp"
+    },
+    "authors": [
+        {
+            "name": "Anton Titov (wolfy-j)",
+            "email": "wolfy-j@spiralscout.com"
+        },
+        {
+            "name": "Aleksei Gagarin (roxblnfk)",
+            "email": "alexey.gagarin@spiralscout.com"
+        },
+        {
+            "name": "Pavel Butchnev (butschster)",
+            "email": "pavel.buchnev@spiralscout.com"
+        },
+        {
+            "name": "Maksim Smakouz (msmakouz)",
+            "email": "maksim.smakouz@spiralscout.com"
+        }
+    ],
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/cycle"
+        }
+    ],
     "require": {
         "php": ">=8.0",
         "cycle/entity-behavior": "^1.3",
@@ -12,7 +45,6 @@
         "spiral/tokenizer": "^2.8",
         "vimeo/psalm": "^5.11"
     },
-    "license": "MIT",
     "autoload": {
         "psr-4": {
             "Cycle\\ORM\\Entity\\Behavior\\Uuid\\": "src/"

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -6,6 +6,7 @@ namespace Cycle\ORM\Entity\Behavior\Uuid;
 
 use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
+use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Registry;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 
@@ -20,7 +21,11 @@ abstract class Uuid extends BaseModifier
         $modifier = new RegistryModifier($registry, $this->role);
         $this->column = $modifier->findColumnName($this->field, $this->column);
         if ($this->column !== null) {
-            $modifier->addUuidColumn($this->column, $this->field)->nullable($this->nullable);
+            $modifier->addUuidColumn(
+                $this->column,
+                $this->field,
+                $this->nullable ? null : SchemaInterface::GENERATED_PHP_INSERT
+            )->nullable($this->nullable);
             $modifier->setTypecast(
                 $registry->getEntity($this->role)->getFields()->get($this->field),
                 [RamseyUuid::class, 'fromString']
@@ -33,7 +38,11 @@ abstract class Uuid extends BaseModifier
         $modifier = new RegistryModifier($registry, $this->role);
         $this->column = $modifier->findColumnName($this->field, $this->column) ?? $this->field;
 
-        $modifier->addUuidColumn($this->column, $this->field)->nullable($this->nullable);
+        $modifier->addUuidColumn(
+            $this->column,
+            $this->field,
+            $this->nullable ? null : SchemaInterface::GENERATED_PHP_INSERT
+        )->nullable($this->nullable);
         $modifier->setTypecast(
             $registry->getEntity($this->role)->getFields()->get($this->field),
             [RamseyUuid::class, 'fromString']

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -6,7 +6,7 @@ namespace Cycle\ORM\Entity\Behavior\Uuid;
 
 use Cycle\ORM\Entity\Behavior\Schema\BaseModifier;
 use Cycle\ORM\Entity\Behavior\Schema\RegistryModifier;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Cycle\Schema\Registry;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 
@@ -24,7 +24,7 @@ abstract class Uuid extends BaseModifier
             $modifier->addUuidColumn(
                 $this->column,
                 $this->field,
-                $this->nullable ? null : SchemaInterface::GENERATED_PHP_INSERT
+                $this->nullable ? null : GeneratedField::BEFORE_INSERT
             )->nullable($this->nullable);
             $modifier->setTypecast(
                 $registry->getEntity($this->role)->getFields()->get($this->field),
@@ -41,7 +41,7 @@ abstract class Uuid extends BaseModifier
         $modifier->addUuidColumn(
             $this->column,
             $this->field,
-            $this->nullable ? null : SchemaInterface::GENERATED_PHP_INSERT
+            $this->nullable ? null : GeneratedField::BEFORE_INSERT
         )->nullable($this->nullable);
         $modifier->setTypecast(
             $registry->getEntity($this->role)->getFields()->get($this->field),

--- a/tests/Uuid/Functional/Driver/Common/Uuid/UuidTest.php
+++ b/tests/Uuid/Functional/Driver/Common/Uuid/UuidTest.php
@@ -9,7 +9,7 @@ use Cycle\ORM\Entity\Behavior\Uuid\Tests\Fixtures\Uuid\NullableUuid;
 use Cycle\ORM\Entity\Behavior\Uuid\Tests\Fixtures\Uuid\Post;
 use Cycle\ORM\Entity\Behavior\Uuid\Tests\Fixtures\Uuid\User;
 use Cycle\ORM\Entity\Behavior\Uuid\Tests\Functional\Driver\Common\BaseTest;
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Cycle\Schema\Registry;
 use Ramsey\Uuid\Uuid;
 use Spiral\Attributes\ReaderInterface;
@@ -45,7 +45,7 @@ abstract class UuidTest extends BaseTest
         $this->assertTrue($fields->hasColumn('uuid'));
         $this->assertSame('uuid', $fields->get('uuid')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('uuid')->getTypecast());
-        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('uuid')->getGenerated());
+        $this->assertSame(GeneratedField::BEFORE_INSERT, $fields->get('uuid')->getGenerated());
         $this->assertSame(1, $fields->count());
     }
 
@@ -62,7 +62,7 @@ abstract class UuidTest extends BaseTest
         $this->assertTrue($fields->hasColumn('custom_uuid'));
         $this->assertSame('uuid', $fields->get('customUuid')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('customUuid')->getTypecast());
-        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('customUuid')->getGenerated());
+        $this->assertSame(GeneratedField::BEFORE_INSERT, $fields->get('customUuid')->getGenerated());
     }
 
     /**
@@ -78,25 +78,25 @@ abstract class UuidTest extends BaseTest
         $this->assertTrue($fields->hasColumn('uuid'));
         $this->assertSame('uuid', $fields->get('uuid')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('uuid')->getTypecast());
-        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('uuid')->getGenerated());
+        $this->assertSame(GeneratedField::BEFORE_INSERT, $fields->get('uuid')->getGenerated());
 
         $this->assertTrue($fields->has('otherUuid'));
         $this->assertTrue($fields->hasColumn('other_uuid'));
         $this->assertSame('uuid', $fields->get('otherUuid')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('otherUuid')->getTypecast());
-        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('otherUuid')->getGenerated());
+        $this->assertSame(GeneratedField::BEFORE_INSERT, $fields->get('otherUuid')->getGenerated());
 
         $this->assertTrue($fields->has('uuid7'));
         $this->assertTrue($fields->hasColumn('uuid7'));
         $this->assertSame('uuid', $fields->get('uuid7')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('uuid7')->getTypecast());
-        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('uuid7')->getGenerated());
+        $this->assertSame(GeneratedField::BEFORE_INSERT, $fields->get('uuid7')->getGenerated());
 
         $this->assertTrue($fields->has('otherUuid7'));
         $this->assertTrue($fields->hasColumn('other_uuid7'));
         $this->assertSame('uuid', $fields->get('otherUuid7')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('otherUuid7')->getTypecast());
-        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('otherUuid7')->getGenerated());
+        $this->assertSame(GeneratedField::BEFORE_INSERT, $fields->get('otherUuid7')->getGenerated());
     }
 
     /**

--- a/tests/Uuid/Functional/Driver/Common/Uuid/UuidTest.php
+++ b/tests/Uuid/Functional/Driver/Common/Uuid/UuidTest.php
@@ -9,6 +9,7 @@ use Cycle\ORM\Entity\Behavior\Uuid\Tests\Fixtures\Uuid\NullableUuid;
 use Cycle\ORM\Entity\Behavior\Uuid\Tests\Fixtures\Uuid\Post;
 use Cycle\ORM\Entity\Behavior\Uuid\Tests\Fixtures\Uuid\User;
 use Cycle\ORM\Entity\Behavior\Uuid\Tests\Functional\Driver\Common\BaseTest;
+use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Registry;
 use Ramsey\Uuid\Uuid;
 use Spiral\Attributes\ReaderInterface;
@@ -44,6 +45,7 @@ abstract class UuidTest extends BaseTest
         $this->assertTrue($fields->hasColumn('uuid'));
         $this->assertSame('uuid', $fields->get('uuid')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('uuid')->getTypecast());
+        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('uuid')->getGenerated());
         $this->assertSame(1, $fields->count());
     }
 
@@ -60,6 +62,7 @@ abstract class UuidTest extends BaseTest
         $this->assertTrue($fields->hasColumn('custom_uuid'));
         $this->assertSame('uuid', $fields->get('customUuid')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('customUuid')->getTypecast());
+        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('customUuid')->getGenerated());
     }
 
     /**
@@ -75,21 +78,25 @@ abstract class UuidTest extends BaseTest
         $this->assertTrue($fields->hasColumn('uuid'));
         $this->assertSame('uuid', $fields->get('uuid')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('uuid')->getTypecast());
+        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('uuid')->getGenerated());
 
         $this->assertTrue($fields->has('otherUuid'));
         $this->assertTrue($fields->hasColumn('other_uuid'));
         $this->assertSame('uuid', $fields->get('otherUuid')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('otherUuid')->getTypecast());
+        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('otherUuid')->getGenerated());
 
         $this->assertTrue($fields->has('uuid7'));
         $this->assertTrue($fields->hasColumn('uuid7'));
         $this->assertSame('uuid', $fields->get('uuid7')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('uuid7')->getTypecast());
+        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('uuid7')->getGenerated());
 
         $this->assertTrue($fields->has('otherUuid7'));
         $this->assertTrue($fields->hasColumn('other_uuid7'));
         $this->assertSame('uuid', $fields->get('otherUuid7')->getType());
         $this->assertSame([Uuid::class, 'fromString'], $fields->get('otherUuid7')->getTypecast());
+        $this->assertSame(SchemaInterface::GENERATED_PHP_INSERT, $fields->get('otherUuid7')->getGenerated());
     }
 
     /**
@@ -111,5 +118,6 @@ abstract class UuidTest extends BaseTest
                 ->column('not_defined_uuid')
                 ->isNullable()
         );
+        $this->assertNull($fields->get('notDefinedUuid')->getGenerated());
     }
 }


### PR DESCRIPTION
## What was changed

Added support for `GENERATED_FIELDS` in the schema, which will be in the next version of Cycle ORM

## Checklist

- [x] https://github.com/cycle/orm/pull/462
- [x] https://github.com/cycle/schema-builder/pull/73
- [x] https://github.com/cycle/entity-behavior/pull/31